### PR TITLE
[ADD] hr_timesheet_overtime: access rights on page overtime

### DIFF
--- a/hr_timesheet_overtime/models/hr_employee.py
+++ b/hr_timesheet_overtime/models/hr_employee.py
@@ -32,6 +32,28 @@ class HrEmployee(models.Model):
         help="Overtime Start Date to compute overtime",
     )
 
+    has_overtime_access = fields.Boolean(
+        string="Has access to overtime page",
+        compute="_compute_has_overtime_access",
+    )
+
+    @api.multi
+    def _compute_has_overtime_access(self):
+        for rec in self:
+            has_access = False
+            if self.env.user.has_group(
+                "base.group_hr_manager"
+            ) or self.env.user.has_group("base.group_hr_user"):
+                has_access = True
+            elif (
+                rec.user_id.employee_ids.parent_id.id
+                == self.env.user.employee_ids.id
+            ):
+                has_access = True
+            elif rec.user_id == self.env.user:
+                has_access = True
+            rec.has_overtime_access = has_access
+
     @api.multi
     def _compute_total_overtime(self):
         """

--- a/hr_timesheet_overtime/views/hr_employee_view.xml
+++ b/hr_timesheet_overtime/views/hr_employee_view.xml
@@ -10,9 +10,12 @@
         <field name="inherit_id" ref="hr.view_employee_form"/>
         <field name="arch" type="xml">
             <xpath expr="//notebook" position="inside">
-                <page name="overtime" string="Overtime">
+                <page name="overtime"
+                      string="Overtime"
+                      attrs="{'invisible': [('has_overtime_access', '=', False)]}">
                     <group>
-                        <group name="overtime" string="Overtime" groups="base.group_hr_user">
+                        <group name="overtime" string="Overtime">
+                            <field name="has_overtime_access" invisible="True"/>
                             <field name="initial_overtime" widget="float_time"/>
                             <field name="total_overtime" widget="float_time"/>
                             <field name="overtime_start_date"/>


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web#id=3843&view_type=form&model=project.task&menu_id=338&action=479)
La demande : 
- Un employé voit uniquement son onglet "Overtime"
- Un chef de département son onglet et ceux de ses employés
- Un responsable RH voit tout