### PR TITLE
[REM] hr_timesheet_overtime: remove total_overtime from timesheet sheet tree view

### DIFF
--- a/hr_timesheet_overtime/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_overtime/models/hr_timesheet_sheet.py
@@ -130,6 +130,7 @@ class HrTimesheetSheet(models.Model):
         self.ensure_one()
         ts_day = self.env["hr_timesheet_sheet.sheet.day"].search(
             [
+                ("sheet_id.active", "=", True),
                 ("sheet_id.employee_id.id", "=", self.employee_id.id),
                 ("sheet_id.date_from", ">=", self.date_from),
                 ("sheet_id.date_to", "<=", self.date_to),

--- a/hr_timesheet_overtime/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_overtime/models/hr_timesheet_sheet.py
@@ -13,6 +13,7 @@ _logger = logging.getLogger(__name__)
 class HrTimesheetSheet(models.Model):
     _inherit = "hr_timesheet_sheet.sheet"
 
+    active = fields.Boolean("Active", default=True)
     # Numeric fields
     daily_working_hours = fields.Float(
         "Daily Working Hours",

--- a/hr_timesheet_overtime/views/hr_timesheet_sheet_view.xml
+++ b/hr_timesheet_overtime/views/hr_timesheet_sheet_view.xml
@@ -19,18 +19,6 @@
         </field>
     </record>
 
-    <record id="hr_timesheet_sheet_tree_simplified" model="ir.ui.view">
-        <field name="name">hr.timesheet.sheet.tree</field>
-        <field name="model">hr_timesheet_sheet.sheet</field>
-        <field name="inherit_id" ref="hr_timesheet_sheet.hr_timesheet_sheet_tree_simplified"/>
-
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='date_to']" position="after">
-                <field name="total_overtime" widget="float_time"/>
-            </xpath>
-        </field>
-    </record>
-
     <menuitem name="Overtime Rate"
               id="menu_hr_overtime_rate" sequence="100"
               parent="hr_attendance.timesheet_menu_root"

--- a/hr_timesheet_overtime/views/hr_timesheet_sheet_view.xml
+++ b/hr_timesheet_overtime/views/hr_timesheet_sheet_view.xml
@@ -10,11 +10,31 @@
         <field name="model">hr_timesheet_sheet.sheet</field>
         <field name="inherit_id" ref="hr_timesheet_sheet.hr_timesheet_sheet_form"/>
         <field name="arch" type="xml">
+
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-check">
+                    <field name="active" widget="boolean_button" options='{"terminology": "active"}'/>
+                </button>
+            </xpath>
+
             <xpath expr="//group/group/label[@for='date_from']" position="before">
                 <field name="daily_working_hours" widget="float_time"/>
                 <field name="daily_overtime" widget="float_time"/>
                 <field name="total_overtime" widget="float_time"/>
             </xpath>
+
+        </field>
+    </record>
+
+    <record id="view_hr_timesheet_sheet_filter" model="ir.ui.view">
+        <field name="name">hr.timesheet.sheet.filter</field>
+        <field name="model">hr_timesheet_sheet.sheet</field>
+        <field name="inherit_id" ref="hr_timesheet_sheet.view_hr_timesheet_sheet_filter"/>
+        <field name="arch" type="xml">
+
+            <filter name="message_needaction" position="after">
+                <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
+            </filter>
 
         </field>
     </record>


### PR DESCRIPTION
Remove total_overtime from timesheet sheet tree view in the hope to prevent computation of all and speed up these views.