### PR TITLE
12.0 extend overtime access to all superiors

### DIFF
--- a/hr_timesheet_overtime/models/hr_employee.py
+++ b/hr_timesheet_overtime/models/hr_employee.py
@@ -44,7 +44,7 @@ class HrEmployee(models.Model):
         help="Overtime Start Date to compute overtime",
     )
 
-    has_overtime_access = fields.Boolean(
+    _has_overtime_access = fields.Boolean(
         string="Has access to overtime page",
         compute="_compute_has_overtime_access",
     )
@@ -106,7 +106,7 @@ class HrEmployee(models.Model):
                     ]
                 )
                 has_access = rec in subordinates
-            rec.has_overtime_access = has_access
+            rec._has_overtime_access = has_access
 
     @api.multi
     @api.depends("timesheet_sheet_ids.active")

--- a/hr_timesheet_overtime/models/hr_employee.py
+++ b/hr_timesheet_overtime/models/hr_employee.py
@@ -92,13 +92,13 @@ class HrEmployee(models.Model):
                 "hr.group_hr_manager"
             ) or self.env.user.has_group("hr.group_hr_user"):
                 has_access = True
-            elif (
-                rec.user_id.employee_ids.parent_id.id
-                == self.env.user.employee_ids.id
-            ):
-                has_access = True
             elif rec.user_id == self.env.user:
                 has_access = True
+            else:
+                subordinates = self.env["hr.employee"].search(
+                    [("id", "child_of", self.env.user.employee_ids.mapped("id"))]
+                )
+                has_access = rec in subordinates
             rec.has_overtime_access = has_access
 
     @api.multi

--- a/hr_timesheet_overtime/views/hr_employee_view.xml
+++ b/hr_timesheet_overtime/views/hr_employee_view.xml
@@ -13,11 +13,11 @@
                 <page
                     name="overtime"
                     string="Overtime"
-                    attrs="{'invisible': [('has_overtime_access', '=', False)]}"
+                    attrs="{'invisible': [('_has_overtime_access', '=', False)]}"
                 >
                     <group>
                         <group name="overtime" string="Overtime">
-                            <field name="has_overtime_access" invisible="True" />
+                            <field name="_has_overtime_access" invisible="True" />
                             <field name="initial_overtime" widget="float_time" />
                             <field name="total_overtime" widget="float_time" />
                             <field name="overtime_start_date" />


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web#id=7822&view_type=form&model=project.task&action=479)

- change computation of `has_overtime_access` to apply to all superiors (not only n+1)
- restrict writing to `initial_overtime` and `overtime_start_date` only to HR
- set has_overtime_access as a private variable