### PR TITLE
[IMP] use standard access rights

### DIFF
--- a/hr_timesheet_overtime/models/hr_employee.py
+++ b/hr_timesheet_overtime/models/hr_employee.py
@@ -8,8 +8,6 @@ from pytz import timezone
 from odoo import _, api, fields, models
 from odoo.exceptions import AccessError
 
-OVERTIME_WRITE_ACCESS_GROUPS = ("hr.group_hr_user", "hr.group_hr_manager")
-
 
 class HrEmployee(models.Model):
     _inherit = "hr.employee"
@@ -24,11 +22,13 @@ class HrEmployee(models.Model):
         string="Initial Overtime",
         default=0.0,
         help="Initial Overtime to start Overtime Start Date with",
+        groups="hr.group_hr_user",
     )
     total_overtime = fields.Float(
         string="Total Overtime",
         compute="_compute_total_overtime",
         help="Total Overtime since Overtime Start Date",
+        groups="hr.group_hr_user",
     )
     timesheet_sheet_ids = fields.One2many(
         comodel_name="hr_timesheet.sheet",
@@ -42,11 +42,7 @@ class HrEmployee(models.Model):
         required=True,
         default=date.today().replace(month=1, day=1),
         help="Overtime Start Date to compute overtime",
-    )
-
-    _has_overtime_access = fields.Boolean(
-        string="Has access to overtime page",
-        compute="_compute_has_overtime_access",
+        groups="hr.group_hr_user",
     )
 
     @api.multi
@@ -88,27 +84,6 @@ class HrEmployee(models.Model):
             )
 
     @api.multi
-    def _compute_has_overtime_access(self):
-        for rec in self:
-            has_access = False
-            if self._has_overtime_write_access():
-                has_access = True
-            elif rec.user_id == self.env.user:
-                has_access = True
-            else:
-                subordinates = self.env["hr.employee"].search(
-                    [
-                        (
-                            "id",
-                            "child_of",
-                            self.env.user.employee_ids.mapped("id"),
-                        )
-                    ]
-                )
-                has_access = rec in subordinates
-            rec._has_overtime_access = has_access
-
-    @api.multi
     @api.depends("timesheet_sheet_ids.active")
     def _compute_total_overtime(self):
         """
@@ -123,22 +98,3 @@ class HrEmployee(models.Model):
             )
             overtime = sum(sheet.timesheet_overtime for sheet in sheets)
             employee.total_overtime = employee.initial_overtime + overtime
-
-    def _has_overtime_write_access(self):
-        for group in OVERTIME_WRITE_ACCESS_GROUPS:
-            if self.env.user.has_group(group):
-                return True
-        return False
-
-    def write(self, vals):
-        for restricted_field in ["initial_overtime", "overtime_start_date"]:
-            if (
-                restricted_field in vals
-                and self[restricted_field] != vals[restricted_field]
-                and not self._has_overtime_write_access()
-            ):
-                raise AccessError(
-                    _("You do not have the permission to modify this field.")
-                )
-
-        return super(HrEmployee, self).write(vals)

--- a/hr_timesheet_overtime/models/hr_employee.py
+++ b/hr_timesheet_overtime/models/hr_employee.py
@@ -5,8 +5,7 @@ from datetime import date, datetime, timedelta
 
 from pytz import timezone
 
-from odoo import _, api, fields, models
-from odoo.exceptions import AccessError
+from odoo import api, fields, models
 
 
 class HrEmployee(models.Model):

--- a/hr_timesheet_overtime/models/hr_employee.py
+++ b/hr_timesheet_overtime/models/hr_employee.py
@@ -28,7 +28,8 @@ class HrEmployee(models.Model):
         string="Total Overtime",
         compute="_compute_total_overtime",
         help="Total Overtime since Overtime Start Date",
-        groups="hr.group_hr_user",
+        # this field has no groups restriction because an employee should be
+        # able to access their own total overtime.
     )
     timesheet_sheet_ids = fields.One2many(
         comodel_name="hr_timesheet.sheet",

--- a/hr_timesheet_overtime/models/hr_employee.py
+++ b/hr_timesheet_overtime/models/hr_employee.py
@@ -21,14 +21,11 @@ class HrEmployee(models.Model):
         string="Initial Overtime",
         default=0.0,
         help="Initial Overtime to start Overtime Start Date with",
-        groups="hr.group_hr_user",
     )
     total_overtime = fields.Float(
         string="Total Overtime",
         compute="_compute_total_overtime",
         help="Total Overtime since Overtime Start Date",
-        # this field has no groups restriction because an employee should be
-        # able to access their own total overtime.
     )
     timesheet_sheet_ids = fields.One2many(
         comodel_name="hr_timesheet.sheet",
@@ -42,7 +39,6 @@ class HrEmployee(models.Model):
         required=True,
         default=date.today().replace(month=1, day=1),
         help="Overtime Start Date to compute overtime",
-        groups="hr.group_hr_user",
     )
 
     @api.multi

--- a/hr_timesheet_overtime/security/ir.model.access.csv
+++ b/hr_timesheet_overtime/security/ir.model.access.csv
@@ -1,4 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_resource_overtime,resource.overtime,model_resource_overtime,hr.group_hr_manager,1,1,1,1
-access_resource_overtime_rate,resource.overtime.rate,model_resource_overtime_rate,hr.group_hr_manager,1,1,1,1
+access_resource_overtime,resource.overtime,model_resource_overtime,hr.group_hr_user,1,1,1,1
+access_resource_overtime_rate,resource.overtime.rate,model_resource_overtime_rate,hr.group_hr_user,1,1,1,1
 access_resource_overtime_rate_user,resource.overtime.rate,model_resource_overtime_rate,base.group_user,1,0,0,0

--- a/hr_timesheet_overtime/views/hr_employee_view.xml
+++ b/hr_timesheet_overtime/views/hr_employee_view.xml
@@ -13,11 +13,10 @@
                 <page
                     name="overtime"
                     string="Overtime"
-                    attrs="{'invisible': [('_has_overtime_access', '=', False)]}"
+                    groups="hr.group_hr_user"
                 >
                     <group>
                         <group name="overtime" string="Overtime">
-                            <field name="_has_overtime_access" invisible="True" />
                             <field name="initial_overtime" widget="float_time" />
                             <field name="total_overtime" widget="float_time" />
                             <field name="overtime_start_date" />

--- a/hr_timesheet_overtime/views/hr_employee_view.xml
+++ b/hr_timesheet_overtime/views/hr_employee_view.xml
@@ -10,11 +10,7 @@
         <field name="inherit_id" ref="hr.view_employee_form" />
         <field name="arch" type="xml">
             <xpath expr="//notebook" position="inside">
-                <page
-                    name="overtime"
-                    string="Overtime"
-                    groups="hr.group_hr_user"
-                >
+                <page name="overtime" string="Overtime" groups="hr.group_hr_user">
                     <group>
                         <group name="overtime" string="Overtime">
                             <field name="initial_overtime" widget="float_time" />

--- a/hr_timesheet_overtime/views/hr_timesheet_sheet_view.xml
+++ b/hr_timesheet_overtime/views/hr_timesheet_sheet_view.xml
@@ -87,10 +87,17 @@
     </record>
 
     <menuitem
-        name="Overtime Rate"
-        id="menu_hr_overtime_rate"
-        sequence="100"
+        name="Overtime"
+        id="menu_hr_timesheet_overtime"
+        sequence="99"
         parent="hr_timesheet.timesheet_menu_root"
+    />
+
+    <menuitem
+        name="Overtime Rate"
+        id="menu_hr_timesheet_overtime_rate"
+        sequence="100"
+        parent="menu_hr_timesheet_overtime"
         groups="hr.group_hr_manager"
         action="action_resource_overtime_form"
     />


### PR DESCRIPTION
*   replace custom access rights by standard groups.
*   use `hr.group_hr_user` instead of `hr.group_hr_manager` for full access to `resource.overtime` and `resource.overtime.rate`.
*   move the overtime rate menuitem under an overtime menuitem to allow for overtime sub-menuitems.

this is related to coopiteasy/cie-custom#60.