### PR TITLE
[16.0][FIX] hr_timesheet_overtime: Make write function accept multiple records

### DIFF
--- a/hr_timesheet_overtime/models/account_analytic_line.py
+++ b/hr_timesheet_overtime/models/account_analytic_line.py
@@ -23,8 +23,14 @@ class AnalyticLine(models.Model):
 
     def write(self, values):
         if not self.env.context.get("create"):  # sale module
-            self._update_values(values)
-        return super().write(values)
+            for record in self:
+                # TODO: this is slow and inefficient.
+                vals_copy = values.copy()
+                record._update_values(vals_copy)
+                super(AnalyticLine, record).write(vals_copy)
+            return True
+        else:
+            return super().write(values)
 
     def _update_values(self, values):
         """

--- a/hr_timesheet_overtime/tests/test_overtime.py
+++ b/hr_timesheet_overtime/tests/test_overtime.py
@@ -421,3 +421,34 @@ class TestOvertime(TransactionCase):
             self.assertEqual(self.ts1.working_time, 9 * 5)
             # Affected by the extra overtime
             self.assertEqual(self.ts1.timesheet_overtime, 2)
+
+    def test_write_multiple_lines(self):
+        """When writing multiple analytic lines, overtime rates are applied
+        separately to each record.
+        """
+        overtime = self.env["resource.overtime"].create({"name": "test"})
+        self.env["resource.overtime.rate"].create(
+            {
+                "name": "test",
+                "dayofweek": "0",  # Monday
+                "rate": 2.0,
+                "overtime_id": overtime.id,
+            }
+        )
+
+        lines = self.env["account.analytic.line"].browse()
+        # monday and tuesday
+        for day in range(9, 11):
+            lines += self.env["account.analytic.line"].create(
+                {
+                    "project_id": self.project_01.id,
+                    "amount": 0.0,
+                    "date": date(2019, 12, day),
+                    "name": "-",
+                    "employee_id": self.employee1.id,
+                }
+            )
+        lines.write({"unit_amount": 1})
+
+        self.assertEqual(lines[0].unit_amount, 2)
+        self.assertEqual(lines[1].unit_amount, 1)


### PR DESCRIPTION


## Description

I'm really not sure how this ever did not break before.

## Odoo task (if applicable)

T12629

## Checklist before approval

- [x] Tests are present (or not needed).
- [x] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [x] (If a new module) Moving this to OCA has been considered.
