### PR TITLE
[12.0][ADD] hr_timesheet_sheet_prefill_multi

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -15,7 +15,8 @@ odoo_test_flavor: OCB
 odoo_version: 12.0
 org_name: Coop IT Easy SC
 org_slug: coopiteasy
-rebel_module_groups: []
+rebel_module_groups:
+- hr_timesheet_sheet_prefill_multi
 repo_description: hr_timesheet modules
 repo_name: cie-timesheet
 repo_slug: cie-timesheet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,11 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.6-ocb12.0:latest
+            include: "hr_timesheet_sheet_prefill_multi"
+            name: test with OCB
+            makepot: "true"
+          - container: ghcr.io/oca/oca-ci/py3.6-ocb12.0:latest
+            exclude: "hr_timesheet_sheet_prefill_multi"
             name: test with OCB
             makepot: "true"
     services:
@@ -30,6 +35,9 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
+    env:
+      INCLUDE: "${{ matrix.include }}"
+      EXCLUDE: "${{ matrix.exclude }}"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/hr_timesheet_sheet_prefill/__manifest__.py
+++ b/hr_timesheet_sheet_prefill/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Timesheet Sheet prefill",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.1.0",
     "category": "Human Resources",
     "summary": "Prefill a timesheet sheet with daily timesheets",
     "author": "Coop IT Easy SC, Odoo Community Association (OCA)",

--- a/hr_timesheet_sheet_prefill/models/hr_employee.py
+++ b/hr_timesheet_sheet_prefill/models/hr_employee.py
@@ -12,11 +12,9 @@ class Employee(models.Model):
         comodel_name="project.project",
         relation="hr_employee_project_project_rel",
         string="Projects",
-        domain=[("active", "=", True)],
     )
 
-    # This exists solely extension in hr_timesheet_sheet_prefill_multi, and also
-    # to filter out inactive projects.
+    # This exists solely for extension in hr_timesheet_sheet_prefill_multi.
     def all_prefill_projects(self):
         self.ensure_one()
-        return self.project_ids.filtered(lambda project: project.active)
+        return self.project_ids

--- a/hr_timesheet_sheet_prefill/models/hr_employee.py
+++ b/hr_timesheet_sheet_prefill/models/hr_employee.py
@@ -8,4 +8,8 @@ from odoo import fields, models
 class Employee(models.Model):
     _inherit = "hr.employee"
 
-    project_ids = fields.Many2many(comodel_name="project.project", string="Projects")
+    project_ids = fields.Many2many(
+        comodel_name="project.project",
+        relation="hr_employee_project_project_rel",
+        string="Projects",
+    )

--- a/hr_timesheet_sheet_prefill/models/hr_employee.py
+++ b/hr_timesheet_sheet_prefill/models/hr_employee.py
@@ -12,9 +12,11 @@ class Employee(models.Model):
         comodel_name="project.project",
         relation="hr_employee_project_project_rel",
         string="Projects",
+        domain=[("active", "=", True)],
     )
 
-    # This exists solely for extension in hr_timesheet_sheet_prefill_multi.
+    # This exists solely extension in hr_timesheet_sheet_prefill_multi, and also
+    # to filter out inactive projects.
     def all_prefill_projects(self):
         self.ensure_one()
-        return self.project_ids
+        return self.project_ids.filtered(lambda project: project.active)

--- a/hr_timesheet_sheet_prefill/models/hr_employee.py
+++ b/hr_timesheet_sheet_prefill/models/hr_employee.py
@@ -13,3 +13,8 @@ class Employee(models.Model):
         relation="hr_employee_project_project_rel",
         string="Projects",
     )
+
+    # This exists solely for extension in hr_timesheet_sheet_prefill_multi.
+    def all_prefill_projects(self):
+        self.ensure_one()
+        return self.project_ids

--- a/hr_timesheet_sheet_prefill/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_prefill/models/hr_timesheet_sheet.py
@@ -10,21 +10,6 @@ from odoo import api, models
 class Sheet(models.Model):
     _inherit = "hr_timesheet.sheet"
 
-    def get_number_days_between_dates(self, date_start, date_end):
-        """
-        Return the number of days between two dates, including both of them.
-
-        Arguments:
-            date_start (date): start date
-            date_end (date): end date
-
-        Returns:
-            int: the number of days between the provided dates
-        """
-        difference = date_end - date_start
-        # return result and add a day
-        return difference.days + 1
-
     @api.model
     def create(self, vals):
         ts = super().create(vals)
@@ -44,6 +29,23 @@ class Sheet(models.Model):
                 ts.write({"timesheet_ids": [(0, 0, aal_dict)]})
         return ts
 
+    @api.model
+    def get_number_days_between_dates(self, date_start, date_end):
+        """
+        Return the number of days between two dates, including both of them.
+
+        Arguments:
+            date_start (date): start date
+            date_end (date): end date
+
+        Returns:
+            int: the number of days between the provided dates
+        """
+        difference = date_end - date_start
+        # return result and add a day
+        return difference.days + 1
+
+    @api.model
     def _prepare_analytic_line(self, date, project, sheet_id, user_id):
         return {
             "project_id": project.id,

--- a/hr_timesheet_sheet_prefill/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_prefill/models/hr_timesheet_sheet.py
@@ -22,7 +22,7 @@ class Sheet(models.Model):
         days = self.get_number_days_between_dates(date_start, date_end)
         for day in range(days):
             date_current = date_start + timedelta(days=day)
-            for project in employee_id.project_ids:
+            for project in employee_id.all_prefill_projects():
                 aal_dict = self._prepare_analytic_line(
                     date_current, project, sheet_id, employee_id.user_id
                 )

--- a/hr_timesheet_sheet_prefill/models/project_project.py
+++ b/hr_timesheet_sheet_prefill/models/project_project.py
@@ -8,4 +8,8 @@ from odoo import fields, models
 class Project(models.Model):
     _inherit = "project.project"
 
-    employee_ids = fields.Many2many(comodel_name="hr.employee", string="Employees")
+    employee_ids = fields.Many2many(
+        comodel_name="hr.employee",
+        relation="hr_employee_project_project_rel",
+        string="Employees",
+    )

--- a/hr_timesheet_sheet_prefill_multi/__init__.py
+++ b/hr_timesheet_sheet_prefill_multi/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2024 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from . import models

--- a/hr_timesheet_sheet_prefill_multi/__manifest__.py
+++ b/hr_timesheet_sheet_prefill_multi/__manifest__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2024 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+{
+    "name": "Timesheet Sheet prefill with duplicates",
+    "summary": """
+        Allow duplicates in prefill templates.""",
+    "version": "12.0.1.0.0",
+    "category": "Human Resources",
+    "website": "https://coopiteasy.be",
+    "author": "Coop IT Easy SC, Odoo Community Association (OCA)",
+    "maintainers": ["carmenbianca"],
+    "license": "AGPL-3",
+    "application": False,
+    "depends": [
+        "hr_timesheet_sheet_prefill",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/hr_employee_views.xml",
+    ],
+}

--- a/hr_timesheet_sheet_prefill_multi/__manifest__.py
+++ b/hr_timesheet_sheet_prefill_multi/__manifest__.py
@@ -4,15 +4,13 @@
 
 {
     "name": "Timesheet Sheet prefill with duplicates",
-    "summary": """
-        Allow duplicates in prefill templates.""",
+    "summary": "Allow duplicates in prefill templates.",
     "version": "12.0.1.0.0",
     "category": "Human Resources",
     "website": "https://coopiteasy.be",
     "author": "Coop IT Easy SC, Odoo Community Association (OCA)",
     "maintainers": ["carmenbianca"],
     "license": "AGPL-3",
-    "application": False,
     "depends": [
         "hr_timesheet_sheet_prefill",
     ],

--- a/hr_timesheet_sheet_prefill_multi/models/__init__.py
+++ b/hr_timesheet_sheet_prefill_multi/models/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2024 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from . import hr_employee
+from . import hr_timesheet_sheet_prefill

--- a/hr_timesheet_sheet_prefill_multi/models/hr_employee.py
+++ b/hr_timesheet_sheet_prefill_multi/models/hr_employee.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2024 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from odoo import fields, models
+
+
+class HrEmployee(models.Model):
+    _inherit = "hr.employee"
+
+    timesheet_prefill_ids = fields.One2many(
+        comodel_name="hr_timesheet.sheet.prefill",
+        inverse_name="hr_employee_id",
+        string="Prefill Projects",
+        copy=False,
+    )
+
+    def all_prefill_projects(self):
+        self.ensure_one()
+        # The only purpose of the below code is to sort the projects according
+        # to the sequence of the prefill records.
+        projects = self.env["project.project"].browse()
+        for prefill in self.timesheet_prefill_ids.sorted():
+            projects += prefill.project_project_id
+        return projects

--- a/hr_timesheet_sheet_prefill_multi/models/hr_employee.py
+++ b/hr_timesheet_sheet_prefill_multi/models/hr_employee.py
@@ -16,18 +16,13 @@ class HrEmployee(models.Model):
     )
 
     def all_prefill_projects(self):
-        projects = super().all_prefill_projects()
-        # By searching, we get prefills sorted by sequence.
-        prefills = self.env["hr_timesheet.sheet.prefill"].search(
-            [
-                ("project_project_id", "in", projects.ids),
-                ("hr_employee_id", "=", self.id),
-            ]
-        )
-        # Instead of doing `prefills.mapped("project_project_id")`, we manually
-        # create the recordset. This is because the recordset MAY contain
-        # duplicates, and `mapped()` removes duplicates.
-        result = self.env["project.project"]
-        for prefill in prefills:
-            result += prefill.project_project_id
-        return result
+        self.ensure_one()
+        # The only purpose of the below code is to sort the projects according
+        # to the sequence of the prefill records. Instead of doing
+        # `self.timesheet_prefill_ids.mapped("project_project_id")`, we
+        # manually create the recordset. This is because the recordset MAY
+        # contain duplicates, and `mapped()` removes duplicates.
+        projects = self.env["project.project"].browse()
+        for prefill in self.timesheet_prefill_ids:
+            projects += prefill.project_project_id
+        return projects

--- a/hr_timesheet_sheet_prefill_multi/models/hr_timesheet_sheet_prefill.py
+++ b/hr_timesheet_sheet_prefill_multi/models/hr_timesheet_sheet_prefill.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2024 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from odoo import api, fields, models
+
+
+class HrTimesheetSheetPrefill(models.Model):
+    _name = "hr_timesheet.sheet.prefill"
+    _description = "Timesheet prefill line"
+    _order = "sequence, id"
+    # This is a weird hack, inspired by what is done in the `mail` module for
+    # the `mail.notification` model. That model, like this one, is a model
+    # doubling as a Many2many table. In `hr_timesheet_sheet_prefill`, the below
+    # Many2many relation table is created. Here, we claim that table for
+    # ourselves to add the functionality we want, while still preserving the
+    # original Many2many functionality without any changes upstream.
+    _table = "hr_employee_project_project_rel"
+    _rec_name = "project_project_id"
+
+    hr_employee_id = fields.Many2one(
+        string="Employee",
+        comodel_name="hr.employee",
+        ondelete="cascade",
+        required=True,
+    )
+    project_project_id = fields.Many2one(
+        string="Project",
+        comodel_name="project.project",
+        ondelete="cascade",
+        required=True,
+    )
+
+    sequence = fields.Integer(string="Sequence", default=10)
+
+    @api.model_cr
+    def init(self):
+        # Add id column if it doesn't exist yet.
+        self.env.cr.execute(
+            """
+            DO $$
+            BEGIN
+                IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                               WHERE table_name='hr_employee_project_project_rel'
+                               AND column_name='id') THEN
+                    ALTER TABLE hr_employee_project_project_rel
+                    ADD COLUMN id SERIAL NOT NULL PRIMARY KEY;
+                END IF;
+            END $$;
+            """
+        )
+        # Get rid of the unique constraint from the Many2many relationship.
+        self.env.cr.execute(
+            """
+            ALTER TABLE hr_employee_project_project_rel
+            DROP CONSTRAINT IF EXISTS
+            hr_employee_project_project_r_hr_employee_id_project_projec_key;
+            """
+        )

--- a/hr_timesheet_sheet_prefill_multi/models/hr_timesheet_sheet_prefill.py
+++ b/hr_timesheet_sheet_prefill_multi/models/hr_timesheet_sheet_prefill.py
@@ -30,8 +30,8 @@ class HrTimesheetSheetPrefill(models.Model):
         ondelete="cascade",
         required=True,
     )
-
     sequence = fields.Integer(string="Sequence", default=10)
+    active = fields.Boolean(related="project_project_id.active")
 
     @api.model_cr
     def init(self):

--- a/hr_timesheet_sheet_prefill_multi/readme/CONTRIBUTORS.rst
+++ b/hr_timesheet_sheet_prefill_multi/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Coop IT Easy SC <https://coopiteasy.be>`_:
+
+  * Carmen Bianca BAKKER

--- a/hr_timesheet_sheet_prefill_multi/readme/DESCRIPTION.rst
+++ b/hr_timesheet_sheet_prefill_multi/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Allow duplicates in prefill templates.

--- a/hr_timesheet_sheet_prefill_multi/readme/ROADMAP.rst
+++ b/hr_timesheet_sheet_prefill_multi/readme/ROADMAP.rst
@@ -1,0 +1,5 @@
+As part of installing this module, some adjustments are made to an existing
+Many2many table. These adjustments are (presumably?) NOT undone upon
+uninstallation.
+
+A safe way to uninstall this module should be provided.

--- a/hr_timesheet_sheet_prefill_multi/security/ir.model.access.csv
+++ b/hr_timesheet_sheet_prefill_multi/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_hr_timesheet_sheet_prefill_user,hr_timesheet.sheet.prefill.user,model_hr_timesheet_sheet_prefill,base.group_user,1,1,1,1

--- a/hr_timesheet_sheet_prefill_multi/tests/__init__.py
+++ b/hr_timesheet_sheet_prefill_multi/tests/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2024 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from . import test_prefill_multi

--- a/hr_timesheet_sheet_prefill_multi/tests/test_prefill_multi.py
+++ b/hr_timesheet_sheet_prefill_multi/tests/test_prefill_multi.py
@@ -27,6 +27,29 @@ class TestPrefillMulti(TransactionCase):
             }
         )
 
+    def test_all_prefill_projects_filtered_sorted(self):
+        """Prefill projects are sorted and filtered."""
+        project_03 = self.env["project.project"].create({"name": "Project 03"})
+        self.project_02.active = False
+
+        self.employee.timesheet_prefill_ids = [
+            (0, False, {"project_project_id": self.project_01.id, "sequence": 1}),
+            (0, False, {"project_project_id": self.project_02.id, "sequence": 2}),
+            (0, False, {"project_project_id": project_03.id, "sequence": 3}),
+        ]
+        sheet = self.env["hr_timesheet.sheet"].create(
+            {
+                "employee_id": self.employee.id,
+                "date_start": "2024-01-01",
+                "date_end": "2024-01-01",
+            }
+        )
+        self.assertEqual(len(sheet.timesheet_ids), 2)
+        used_projects = sheet.timesheet_ids.mapped("project_id")
+        self.assertIn(self.project_01, used_projects)
+        self.assertNotIn(self.project_02, used_projects)
+        self.assertIn(project_03, used_projects)
+
     def test_project_ids_still_works(self):
         """You can still use project_ids on hr.employee as normally. It will
         create prefill records.
@@ -62,9 +85,9 @@ class TestPrefillMulti(TransactionCase):
     def test_sequenced_repeated_prefills(self):
         """You can repeat and sequence prefills."""
         self.employee.timesheet_prefill_ids = [
-            (0, False, {"project_project_id": self.project_01, "sequence": 1}),
-            (0, False, {"project_project_id": self.project_02, "sequence": 2}),
-            (0, False, {"project_project_id": self.project_01, "sequence": 3}),
+            (0, False, {"project_project_id": self.project_01.id, "sequence": 1}),
+            (0, False, {"project_project_id": self.project_02.id, "sequence": 2}),
+            (0, False, {"project_project_id": self.project_01.id, "sequence": 3}),
         ]
 
         # Sanity check.

--- a/hr_timesheet_sheet_prefill_multi/tests/test_prefill_multi.py
+++ b/hr_timesheet_sheet_prefill_multi/tests/test_prefill_multi.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2024 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from odoo.tests.common import TransactionCase
+
+
+class TestPrefillMulti(TransactionCase):
+    def setUp(self):
+        super().setUp()
+
+        self.project_01 = self.env["project.project"].create({"name": "Project 01"})
+        self.project_02 = self.env["project.project"].create({"name": "Project 02"})
+
+        self.user = self.env["res.users"].create(
+            {
+                "name": "Test",
+                "login": "test",
+                "password": "test",
+            }
+        )
+        self.employee = self.env["hr.employee"].create(
+            {
+                "name": "Test",
+                "user_id": self.user.id,
+                "address_id": self.user.partner_id.id,
+            }
+        )
+
+    def test_project_ids_still_works(self):
+        """You can still use project_ids on hr.employee as normally. It will
+        create prefill records.
+        """
+        projects = self.project_01 | self.project_02
+        self.employee.project_ids = projects
+
+        self.assertEqual(len(self.employee.timesheet_prefill_ids), 2)
+        prefill_01 = self.employee.timesheet_prefill_ids[0]
+        prefill_02 = self.employee.timesheet_prefill_ids[1]
+        # We can't know for sure which project was sorted first, so we do the
+        # below to make sure they are both given a timesheet.
+        self.assertNotEqual(
+            prefill_01.project_project_id, prefill_02.project_project_id
+        )
+        self.assertIn(prefill_01.project_project_id, projects)
+        self.assertIn(prefill_02.project_project_id, projects)
+
+        sheet = self.env["hr_timesheet.sheet"].create(
+            {
+                "employee_id": self.employee.id,
+                "date_start": "2024-01-01",
+                "date_end": "2024-01-01",
+            }
+        )
+        self.assertEqual(len(sheet.timesheet_ids), 2)
+        self.assertNotEqual(
+            sheet.timesheet_ids[0].project_id, sheet.timesheet_ids[1].project_id
+        )
+        self.assertIn(sheet.timesheet_ids[0].project_id, projects)
+        self.assertIn(sheet.timesheet_ids[1].project_id, projects)
+
+    def test_sequenced_repeated_prefills(self):
+        """You can repeat and sequence prefills."""
+        self.employee.timesheet_prefill_ids = [
+            (0, False, {"project_project_id": self.project_01, "sequence": 1}),
+            (0, False, {"project_project_id": self.project_02, "sequence": 2}),
+            (0, False, {"project_project_id": self.project_01, "sequence": 3}),
+        ]
+
+        # Sanity check.
+        self.assertEqual(len(self.employee.project_ids), 3)
+
+        sheet = self.env["hr_timesheet.sheet"].create(
+            {
+                "employee_id": self.employee.id,
+                "date_start": "2024-01-01",
+                "date_end": "2024-01-01",
+            }
+        )
+        self.assertEqual(len(sheet.timesheet_ids), 3)
+        self.assertEqual(sheet.timesheet_ids[0].project_id, self.project_01)
+        self.assertEqual(sheet.timesheet_ids[1].project_id, self.project_02)
+        self.assertEqual(sheet.timesheet_ids[2].project_id, self.project_01)

--- a/hr_timesheet_sheet_prefill_multi/views/hr_employee_views.xml
+++ b/hr_timesheet_sheet_prefill_multi/views/hr_employee_views.xml
@@ -17,8 +17,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         />
         <field name="arch" type="xml">
             <field name="project_ids" position="after">
-                <field name="timesheet_prefill_ids">
-                    <tree string="Prefill Projects" editable="bottom">
+                <field name="timesheet_prefill_ids" string="Projects">
+                    <tree editable="bottom">
                         <field name="sequence" widget="handle" />
                         <field name="project_project_id" />
                     </tree>

--- a/hr_timesheet_sheet_prefill_multi/views/hr_employee_views.xml
+++ b/hr_timesheet_sheet_prefill_multi/views/hr_employee_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+SPDX-FileCopyrightText: 2024 Coop IT Easy SC
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<odoo>
+    <record
+        id="hr_timesheet_default_analytic_account_view_employee_form"
+        model="ir.ui.view"
+    >
+        <field name="name">hr.employee.view.form</field>
+        <field name="model">hr.employee</field>
+        <field
+            name="inherit_id"
+            ref="hr_timesheet_sheet_prefill.hr_timesheet_default_analytic_account_view_employee_form"
+        />
+        <field name="arch" type="xml">
+            <field name="project_ids" position="after">
+                <field name="timesheet_prefill_ids">
+                    <tree string="Prefill Projects" editable="bottom">
+                        <field name="sequence" widget="handle" />
+                        <field name="project_project_id" />
+                    </tree>
+                </field>
+            </field>
+            <field name="project_ids" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/setup/hr_timesheet_sheet_prefill_multi/odoo/addons/hr_timesheet_sheet_prefill_multi
+++ b/setup/hr_timesheet_sheet_prefill_multi/odoo/addons/hr_timesheet_sheet_prefill_multi
@@ -1,0 +1,1 @@
+../../../../hr_timesheet_sheet_prefill_multi

--- a/setup/hr_timesheet_sheet_prefill_multi/setup.py
+++ b/setup/hr_timesheet_sheet_prefill_multi/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
## Description

Be able to both sort and repeat default projects for timesheet sheets.

I'm pretty content with how this module turned out! It is as hacky as it is elegant.

To save myself from having to track two PRs, we can just merge this with `merge patch`. It will also bump `hr_timesheet_sheet_prefill_multi`, but that doesn't really matter. Version numbers are arbitrary, anyway.

## Odoo task (if applicable)

T12533

## Checklist before approval

- [x] Tests are present (or not needed).
- [x] Credits/copyright have been changed correctly.
- [x] (If a new module) Moving this to OCA has been considered.
